### PR TITLE
Test logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/cobaltspeech/log
 
 go 1.14
+
+require github.com/google/go-cmp v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
+github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/logmap/logmap.go
+++ b/internal/logmap/logmap.go
@@ -1,0 +1,195 @@
+/*
+   Copyright (2020) Cobalt Speech and Language Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package logmap
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// FromKeyvals creates an ordered map containing the keys and values of the log message. The keys
+// are formatted to strings, as well as any values that do not implement json.Marshaler or
+// encoding.TextMarshaler.
+//
+// A final value "missing" is inserted if an odd number of values are passed to FromKeyvals.
+func FromKeyvals(keyvals ...interface{}) MapSlice {
+	n := (len(keyvals) + 1) / 2 // +1 to handle case when len is odd
+	m := make(MapSlice, 0, n)
+
+	for i := 0; i < len(keyvals); i += 2 {
+		k := keyvals[i]
+
+		var v interface{} = "missing"
+		if i+1 < len(keyvals) {
+			v = keyvals[i+1]
+		}
+
+		key := fmt.Sprint(k)
+
+		// If v implements json.Marshaler or encoding.TextMarshaler, we
+		// give that a priority over fmt.Sprint
+		var val interface{}
+		switch v.(type) {
+		case json.Marshaler:
+			val = v
+		case encoding.TextMarshaler:
+			val = v
+		default:
+			val = fmt.Sprint(v)
+		}
+
+		m = append(m, MapItem{Key: key, Value: val})
+	}
+
+	return m
+}
+
+type MapItem struct {
+	Key   string
+	Value interface{}
+}
+
+type IndexedMapValue struct {
+	Value interface{}
+	Index uint64
+}
+
+type MapSlice []MapItem
+
+// UnmarshalJSON adds entries from the JSON object to the MapSlice.
+func (ms *MapSlice) UnmarshalJSON(b []byte) error {
+	indexCounter = 0
+
+	m := map[string]IndexedMapValue{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return err
+	}
+
+	type indexedEntry struct {
+		entry MapItem
+		index uint64
+	}
+
+	var sorted []indexedEntry
+	for k, v := range m {
+		sorted = append(sorted, indexedEntry{MapItem{Key: k, Value: v.Value}, v.Index})
+	}
+
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].index < sorted[j].index
+	})
+
+	for _, v := range sorted {
+		*ms = append(*ms, v.entry)
+	}
+
+	return nil
+}
+
+var indexCounter uint64
+
+func nextIndex() uint64 {
+	indexCounter++
+	return indexCounter
+}
+
+// UnmarshalJSON for an indexed map item. Used for sorting the resulting MapSlice.
+func (mi *IndexedMapValue) UnmarshalJSON(b []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+
+	mi.Value = v
+	mi.Index = nextIndex()
+
+	return nil
+}
+
+// JSONString creates an ordered JSON representation of the keys and values in the MapSlice.
+func (ms MapSlice) JSONString() (string, error) {
+	var sb strings.Builder
+	enc := json.NewEncoder(&sb)
+	enc.SetEscapeHTML(false)
+
+	if err := enc.Encode(ms); err != nil {
+		return "", err
+	}
+
+	return sb.String(), nil
+}
+
+func (ms MapSlice) MarshalJSON() ([]byte, error) {
+	buf := &bytes.Buffer{}
+	buf.Write([]byte{'{'})
+
+	for i, mi := range ms {
+		b, err := json.Marshal(&mi.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		buf.WriteString(fmt.Sprintf("%q:", fmt.Sprintf("%v", mi.Key)))
+		buf.Write(b)
+
+		if i < len(ms)-1 {
+			buf.Write([]byte{','})
+		}
+	}
+
+	buf.Write([]byte{'}'})
+
+	return buf.Bytes(), nil
+}
+
+func (ms MapSlice) ToStringMap() map[string]string {
+	out := map[string]string{}
+	for i := range ms {
+		out[ms[i].Key] = StringFromValue(ms[i].Value)
+	}
+
+	return out
+}
+
+// StringFromValue creates a string from the value by calling the value's MarshalJSON or MarshalText
+// methods if present, and otherwise calling fmt.Sprint.
+func StringFromValue(v interface{}) string {
+	switch v.(type) {
+	case json.Marshaler:
+		valBytes, err := json.Marshal(v)
+		if err != nil {
+			panic(err)
+		}
+
+		return string(valBytes)
+
+	case encoding.TextMarshaler:
+		valBytes, err := json.Marshal(v)
+		if err != nil {
+			panic(err)
+		}
+
+		return string(valBytes)
+
+	default:
+		return fmt.Sprint(v)
+	}
+}

--- a/internal/logmap/logmap_test.go
+++ b/internal/logmap/logmap_test.go
@@ -1,0 +1,320 @@
+/*
+   Copyright (2020) Cobalt Speech and Language Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package logmap
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestFromKeyvals(t *testing.T) {
+	tests := map[string]struct {
+		in  []interface{}
+		out MapSlice
+	}{
+		"empty": {},
+		"simple": {
+			[]interface{}{"msg", "Hi there."},
+			MapSlice{MapItem{"msg", "Hi there."}},
+		},
+		"missing": {
+			[]interface{}{"msg"},
+			MapSlice{MapItem{"msg", "missing"}},
+		},
+		"json": {
+			[]interface{}{"msg", "This is a JSONMarshaler.", "item", MapSlice{MapItem{"msg", "Meta!"}}},
+			MapSlice{MapItem{"msg", "This is a JSONMarshaler."}, MapItem{"item", MapSlice{MapItem{"msg", "Meta!"}}}},
+		},
+		"sprintf": {
+			[]interface{}{"msg", 4},
+			MapSlice{MapItem{"msg", "4"}},
+		},
+		"text_marshaler": {
+			[]interface{}{"msg", newTestMarshaler()},
+			MapSlice{MapItem{"msg", newTestMarshaler()}},
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			exp := FromKeyvals(tc.in...)
+
+			diff := cmp.Diff(tc.out, exp, cmpopts.EquateEmpty())
+			if diff != "" {
+				t.Errorf("unexpected output (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+const nilStr = "<nil>"
+
+func TestMapSlice_UnmarshalJSON(t *testing.T) {
+	tests := map[string]struct {
+		starting MapSlice
+		in       string
+
+		resulting MapSlice
+		err       string
+	}{
+		"empty": {
+			in:  "{}",
+			err: nilStr,
+		},
+		"simple": {
+			in:        `{"msg":"Hi there."}`,
+			resulting: MapSlice{MapItem{"msg", "Hi there."}},
+			err:       nilStr,
+		},
+		"already_present": {
+			starting:  MapSlice{MapItem{"msg", "I won't be deleted."}, MapItem{"other", "Me neither."}},
+			in:        `{"msg":"Hi there."}`,
+			resulting: MapSlice{MapItem{"msg", "I won't be deleted."}, MapItem{"other", "Me neither."}, MapItem{"msg", "Hi there."}},
+			err:       nilStr,
+		},
+		"escape_in_key": {
+			in:        `{"\"hi": "Hi there."}`,
+			resulting: MapSlice{MapItem{`"hi`, "Hi there."}},
+			err:       nilStr,
+		},
+		"key_appears_in_value": {
+			in:        `{"msg": "This \"data\": is for you.", "data": "2"}`,
+			resulting: MapSlice{MapItem{"msg", `This "data": is for you.`}, MapItem{"data", "2"}},
+			err:       nilStr,
+		},
+		"bad_json": {
+			in:  "this ain't JSON",
+			err: "invalid character 'h' in literal true (expecting 'r')",
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.starting.UnmarshalJSON([]byte(tc.in))
+
+			errStr := nilStr
+			if err != nil {
+				errStr = err.Error()
+			}
+
+			diff := cmp.Diff(tc.err, errStr)
+			if diff != "" {
+				t.Errorf("unexpected error result (-want +got):\n%s", diff)
+			}
+
+			if tc.err != nilStr && diff == "" {
+				// We don't care about the updates to tc.starting because we wanted an error.
+				return
+			}
+
+			diff = cmp.Diff(tc.resulting, tc.starting, cmpopts.EquateEmpty())
+			if diff != "" {
+				t.Errorf("unexpected MapSlice result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMapSlice_String(t *testing.T) {
+	tests := map[string]struct {
+		starting MapSlice
+		out      string
+		err      string
+	}{
+		"empty": {
+			out: "{}\n",
+			err: nilStr,
+		},
+		"simple": {
+			starting: MapSlice{MapItem{"msg", "Hello world."}},
+			out:      `{"msg":"Hello world."}` + "\n",
+			err:      nilStr,
+		},
+		"text_marshaler": {
+			starting: MapSlice{MapItem{"msg", "Hi"}, MapItem{"data", newTestMarshaler()}},
+			out:      `{"msg":"Hi","data":"my text: 5"}` + "\n",
+			err:      nilStr,
+		},
+		"encoding_fail": {
+			starting: MapSlice{MapItem{"msg", "Hi"}, MapItem{"data", newFailingJSONMarshaler()}},
+			err: "json: error calling MarshalJSON for type logmap.MapSlice: json: error calling " +
+				"MarshalJSON for type *logmap.failingJSONMarshaler: this error is on purpose",
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			exp, err := tc.starting.JSONString()
+
+			errStr := nilStr
+			if err != nil {
+				errStr = err.Error()
+			}
+
+			diff := cmp.Diff(tc.err, errStr)
+			if diff != "" {
+				t.Errorf("unexpected error (-want +got):\n%s", diff)
+			}
+
+			if tc.err != nilStr && diff == "" {
+				// We don't want to check the output because we got the error we wanted.
+				return
+			}
+
+			diff = cmp.Diff(tc.out, exp)
+			if diff != "" {
+				t.Errorf("unexpected output (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMapSlice_ToStringMap(t *testing.T) {
+	tests := map[string]struct {
+		in  MapSlice
+		out map[string]string
+	}{
+		"empty": {},
+		"json": {
+			MapSlice{MapItem{"msg", "Hello."}, MapItem{"data", newTestJSONMarshaler()}},
+			map[string]string{
+				"msg":  "Hello.",
+				"data": `{"fancy JSON":6}`,
+			},
+		},
+		"text_marshaler": {
+			MapSlice{MapItem{"msg", "Hello."}, MapItem{"data", newTestMarshaler()}},
+			map[string]string{
+				"msg":  "Hello.",
+				"data": `"my text: 5"`,
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			exp := tc.in.ToStringMap()
+
+			diff := cmp.Diff(tc.out, exp, cmpopts.EquateEmpty())
+			if diff != "" {
+				t.Errorf("unexpected output (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMapSlice_StringFromValue_panic(t *testing.T) {
+	tests := map[string]struct {
+		in    interface{}
+		panic interface{}
+	}{
+		"json": {
+			newFailingJSONMarshaler(),
+			"json: error calling MarshalJSON for type *logmap.failingJSONMarshaler: this error is on purpose",
+		},
+		"text": {
+			newFailingTextMarshaler(),
+			"json: error calling MarshalText for type *logmap.failingTextMarshaler: this error is on purpose",
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			defer func() {
+				r := recover()
+
+				if r != nil {
+					r = r.(error).Error()
+				}
+
+				diff := cmp.Diff(tc.panic, r)
+				if diff != "" {
+					t.Errorf("unexpected panic message (-want +got):\n%s", diff)
+				}
+			}()
+
+			_ = StringFromValue(tc.in)
+		})
+	}
+}
+
+// testMarshaler is a type that implements the encoding.TextMarshaler interface, for testing.
+type testMarshaler struct {
+	A int
+}
+
+func newTestMarshaler() *testMarshaler {
+	return &testMarshaler{A: 5}
+}
+
+func (t *testMarshaler) MarshalText() ([]byte, error) {
+	return []byte(fmt.Sprintf("my text: %d", t.A)), nil
+}
+
+// testJSONMarshaler is a type that implements the json.JSONMarshaler interface, for testing.
+type testJSONMarshaler testMarshaler
+
+func newTestJSONMarshaler() *testJSONMarshaler {
+	return &testJSONMarshaler{A: 6}
+}
+
+func (t *testJSONMarshaler) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`{"fancy JSON": %d}`, t.A)), nil
+}
+
+type failingTextMarshaler testMarshaler
+
+func newFailingTextMarshaler() *failingTextMarshaler {
+	return &failingTextMarshaler{A: 7}
+}
+
+func (f *failingTextMarshaler) MarshalText() ([]byte, error) {
+	return nil, fmt.Errorf("this error is on purpose")
+}
+
+type failingJSONMarshaler testJSONMarshaler
+
+func newFailingJSONMarshaler() *failingJSONMarshaler {
+	return &failingJSONMarshaler{A: 8}
+}
+
+func (f *failingJSONMarshaler) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("this error is on purpose")
+}

--- a/leveled_test.go
+++ b/leveled_test.go
@@ -135,8 +135,8 @@ func TestLeveledLogger_log_jsonErrors(t *testing.T) {
 	want := `error {}
 error {"msg":"missing"}
 error {"msg":"test this"}
-error {"msg":"logging failure","error":"json: error calling MarshalJSON for type log.mapSlice: json: error calling MarshalText for type *log.failingTextMarshaler: invalid value"}
-error {"msg":"logging failure","error":"json: error calling MarshalJSON for type log.mapSlice: json: error calling MarshalJSON for type *log.failingJSONMarshaler: invalid value"}
+error {"msg":"logging failure","error":"json: error calling MarshalJSON for type logmap.MapSlice: json: error calling MarshalText for type *log.failingTextMarshaler: invalid value"}
+error {"msg":"logging failure","error":"json: error calling MarshalJSON for type logmap.MapSlice: json: error calling MarshalJSON for type *log.failingJSONMarshaler: invalid value"}
 `
 
 	if got := b.String(); strings.TrimSpace(got) != strings.TrimSpace(want) {

--- a/pkg/testinglog/lastminutefilewriter.go
+++ b/pkg/testinglog/lastminutefilewriter.go
@@ -1,0 +1,88 @@
+/*
+   Copyright (2020) Cobalt Speech and Language Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package testinglog
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"sync"
+)
+
+// lastMinuteFileWriter caches writes until ActuallyWrite is called. It only creates a file at the
+// specified path when it begins to actually write.
+type lastMinuteFileWriter struct {
+	path string
+
+	// w is a *os.File if actuallyWrite has been called; otherwise it is a *bytes.Buffer.
+	w    io.Writer
+	b    *bytes.Buffer // This is the buffer that is w until actuallyWrite is called.
+	f    *os.File      // This is the file   that is w after actuallyWrite is called.
+	lock sync.Mutex
+}
+
+func newLastMinuteFileWriter(file string) *lastMinuteFileWriter {
+	b := bytes.Buffer{}
+	return &lastMinuteFileWriter{path: file, w: &b, b: &b}
+}
+
+// Write caches writes for later unless ActuallyWrite has been called.
+func (fw *lastMinuteFileWriter) Write(p []byte) (n int, err error) {
+	fw.lock.Lock()
+	defer fw.lock.Unlock()
+
+	return fw.w.Write(p)
+}
+
+func (fw *lastMinuteFileWriter) actuallyWrite() error {
+	// No one should write/read the cache or check doWrite while we're doing this.
+	fw.lock.Lock()
+	defer fw.lock.Unlock()
+
+	if fw.f != nil {
+		// We already called actuallyWrite.
+		return nil
+	}
+
+	var err error
+
+	fw.f, err = os.Create(fw.path)
+	if err != nil {
+		return err
+	}
+
+	// Write the cache out.
+	_, err = fw.f.Write(fw.b.Bytes())
+	if err != nil {
+		return err
+	}
+
+	// Replace the *bytes.Buffer with the *os.File.
+	fw.w = fw.f
+	fw.b = nil
+
+	return nil
+}
+
+func (fw *lastMinuteFileWriter) Close() error {
+	if fw.f == nil {
+		// We never opened the file.
+		return nil
+	}
+
+	return fw.f.Close()
+}

--- a/pkg/testinglog/lastminutefilewriter_test.go
+++ b/pkg/testinglog/lastminutefilewriter_test.go
@@ -1,0 +1,128 @@
+/*
+   Copyright (2020) Cobalt Speech and Language Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package testinglog
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestLastMinuteFileWriter_concurrent(t *testing.T) {
+	tempFile := makeTempFile(t)
+
+	defer func() {
+		e := os.Remove(tempFile)
+		if e != nil {
+			t.Fatalf("failed to remove temp file: %v", e)
+		}
+	}()
+
+	fw := newLastMinuteFileWriter(tempFile)
+
+	var wg sync.WaitGroup
+
+	numLines := 500
+
+	wg.Add(numLines)
+
+	for i := 0; i < numLines; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			fmt.Fprintln(fw, "this is line", i)
+		}(i)
+	}
+
+	err := fw.actuallyWrite()
+	if err != nil {
+		t.Fatalf("error in call to actuallyWrite: %v", err)
+	}
+
+	wg.Wait()
+
+	err = fw.Close()
+	if err != nil {
+		t.Fatalf("error closing lastMinuteFileWriter: %v", err)
+	}
+
+	// Make sure the lines were all written to the file.
+	found := make(map[int]struct{})
+
+	for _, line := range readLines(t, tempFile) {
+		if !strings.HasPrefix(line, "this is line ") {
+			t.Errorf(`found unexpected line "%s"`, line)
+			continue
+		}
+
+		var val int
+
+		val, err = strconv.Atoi(line[len("this is line "):])
+		if err != nil {
+			t.Errorf(`found unexpected line "%s": %v`, line, err)
+			continue
+		}
+
+		if _, ok := found[val]; ok {
+			t.Errorf(`found duplicate line "%s"`, line)
+			continue
+		}
+
+		found[val] = struct{}{}
+	}
+
+	for i := 0; i < numLines; i++ {
+		if _, ok := found[i]; !ok {
+			t.Errorf(`did not find expected line "this is line %d"`, i)
+		}
+	}
+}
+
+func makeTempFile(t *testing.T) string {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+
+	tempFile := f.Name()
+
+	err = f.Close()
+	if err != nil {
+		t.Fatalf("failed to close temp file: %v", err)
+	}
+
+	return tempFile
+}
+
+func readLines(t *testing.T, file string) []string {
+	b, err := ioutil.ReadFile(file)
+	if err != nil {
+		t.Fatalf("error reading file: %v", err)
+	}
+
+	if b[len(b)-1] != '\n' {
+		t.Fatalf("file should end with newline but ends with '%v'", b[len(b)-1])
+	}
+
+	b = b[:len(b)-1]
+
+	return strings.Split(string(b), "\n")
+}

--- a/pkg/testinglog/logger.go
+++ b/pkg/testinglog/logger.go
@@ -1,0 +1,355 @@
+/*
+   Copyright (2020) Cobalt Speech and Language Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package testinglog
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/cobaltspeech/log/internal/logmap"
+	"github.com/cobaltspeech/log/pkg/level"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// Logger logs messages to a test runner, and can optionally report differences between log messages
+// received and those expected.
+type Logger struct {
+	// runner has its Log method called in order to report log messages if actualWriter is nil, and
+	// its Fail method is called at every unexpected log if doFail is true.
+	runner TestRunner
+
+	// truth contains the expected log messages.
+	truth         []string
+	cur           int
+	truthProvided bool
+
+	// doFail is whether a discrepancy in log messages implies a call to runner.Fail.
+	doFail bool
+
+	// failed is whether the test has failed.
+	failed bool
+
+	// If non-nil, actualFile is where the actual log messages received are written.
+	actualFile *lastMinuteFileWriter
+
+	// If non-nil, ignorer is used to choose log message fields whose values should be ignored
+	// during comparison.
+	ignorer FieldIgnoreFunc
+}
+
+// TestRunner is an interface for an object that can receive reports of test failure and logging. It
+// is the subset of testing.TB that the Logger requires.
+type TestRunner interface {
+	Log(args ...interface{})
+	Fail()
+}
+
+// NewLogger creates a logger that reports all log messages to the provided test runner.
+func NewLogger(runner TestRunner, opts ...LoggerOption) (*Logger, error) {
+	out := Logger{
+		runner: runner,
+		doFail: true,
+	}
+
+	for _, opt := range opts {
+		if err := opt(&out); err != nil {
+			return &out, err
+		}
+	}
+
+	// If the user provided WithActualOutputFile but not WithTruthFile, we want to write to the
+	// actual file even when no failures occur.
+	if !out.truthProvided && out.actualFile != nil {
+		err := out.actualFile.actuallyWrite()
+		if err != nil {
+			return &out, err
+		}
+	}
+
+	return &out, nil
+}
+
+type LoggerOption func(*Logger) error
+
+// WithTruthFile sets the Logger to compare each log message with the log text in the provided file.
+// Each expected log line should be separated from the next by a newline. If there are any
+// differences between expected and received log lines, they are reported to the test runner and the
+// runner's Fail method will be called when Done is called (unless WithoutFailure is used in
+// conjunction with this option).
+//
+// This function does not handle cases where the logging output order is non-deterministic (e.g. if
+// the function being tested uses multiple goroutines).
+func WithTruthFile(file string) LoggerOption {
+	truth, err := ioutil.ReadFile(file)
+	lines := strings.Split(string(truth), "\n")
+
+	if lines[len(lines)-1] == "" {
+		// The file had a final newline or was empty, but we don't want to expect an empty line.
+		lines = lines[:len(lines)-1]
+	}
+
+	return func(l *Logger) error {
+		if l.truthProvided {
+			panic("multiple truth sources provided")
+		}
+
+		l.truth = lines
+		l.truthProvided = true
+
+		return err
+	}
+}
+
+// WithActualOutputFile specifies a file path where all actual log messages are written. If a truth
+// file has been provided with WithTruthFile, the actual output file is only created if actual log
+// messages differ from those in the truth file.
+func WithActualOutputFile(file string) LoggerOption {
+	return func(l *Logger) error {
+		l.actualFile = newLastMinuteFileWriter(file)
+		return nil
+	}
+}
+
+// WithoutFailure sets the Logger to not call Fail() on the test runner even if log messages are
+// different than expected.
+func WithoutFailure() LoggerOption {
+	return func(l *Logger) error {
+		l.doFail = false
+		return nil
+	}
+}
+
+// FieldIgnoreFunc is a function that decides which fields' values should be ignored in a log
+// message.
+type FieldIgnoreFunc func(fields map[string]string) []string
+
+// WithFieldIgnoreFunc provides the Logger with a function that returns a list of fields to ignore
+// in each log message. The keys will still be checked, but not the values. The keys and values in
+// the log message are formatted as strings before being provided to the FieldIgnorer.
+//
+// If ignorer is nil, this option has no effect.
+func WithFieldIgnoreFunc(ignorer FieldIgnoreFunc) LoggerOption {
+	return func(l *Logger) error {
+		l.ignorer = ignorer
+		return nil
+	}
+}
+
+// Error checks whether the Logger expected an error log line next. If not, it's reported to the
+// test runner.
+func (l *Logger) Error(keyvals ...interface{}) {
+	l.compare(level.Error, keyvals...)
+}
+
+// Info checks whether the Logger expected an info log line next. If not, it's reported to the test
+// runner.
+func (l *Logger) Info(keyvals ...interface{}) {
+	l.compare(level.Info, keyvals...)
+}
+
+// Debug checks whether the Logger expected a debug log line next. If not, it's reported to the test
+// runner.
+func (l *Logger) Debug(keyvals ...interface{}) {
+	l.compare(level.Debug, keyvals...)
+}
+
+// Trace checks whether the Logger expected a trace log line next. If not, it's reported to the test
+// runner.
+func (l *Logger) Trace(keyvals ...interface{}) {
+	l.compare(level.Trace, keyvals...)
+}
+
+// log forwards the log message to the actualFile if provided, otherwise to the runner.
+func (l *Logger) log(args ...interface{}) {
+	if l.actualFile == nil {
+		l.runner.Log(args...)
+		return
+	}
+
+	_, err := fmt.Fprint(l.actualFile, args...)
+	if err != nil {
+		l.error(fmt.Errorf("error writing to actual file: %w", err))
+	}
+}
+
+// error reports an error to the test runner and calls runner.Fail immediately.
+func (l *Logger) error(err error) {
+	l.runner.Log(fmt.Sprintf(`%-5s {"msg":"logging failure","error":%q}`+"\n", level.Error, err))
+	l.runner.Fail()
+}
+
+// compare checks whether the provided log data were expected, reporting any differences to
+// l.runner. It also increments the internal log message counter.
+func (l *Logger) compare(lvl level.Level, keyvals ...interface{}) {
+	ms := logmap.FromKeyvals(keyvals...)
+
+	exp, err := ms.JSONString()
+	if err != nil {
+		l.error(fmt.Errorf("error creating log string: %w", err))
+	}
+
+	exp = fmt.Sprintf("%-5s %s", lvl, exp)
+
+	// Log it to either the logWriter or the runner.
+	l.log(exp)
+
+	if !l.truthProvided {
+		return
+	}
+
+	hyp := l.getCurrent()
+
+	// exp comes with a newline at the end so we remove that for comparison.
+	exp = exp[:len(exp)-1]
+
+	// Check if the log lines are equivalent.
+	if !l.cmp(hyp, exp, lvl, ms) {
+		// Log the failure and the diff to the runner.
+		l.runner.Log("unexpected log message (-want +got):\n", replaceNbsp(cmp.Diff(hyp, exp)))
+
+		l.failed = true
+
+		if l.actualFile != nil {
+			// We're going to fail, so we can start writing the actual file.
+			err = l.actualFile.actuallyWrite()
+			if err != nil {
+				l.error(err)
+			}
+		}
+	}
+
+	l.cur++
+}
+
+func (l *Logger) getCurrent() string {
+	if l.cur < len(l.truth) {
+		return l.truth[l.cur]
+	}
+
+	// We've moved beyond the list of truth log messages we received.
+	return ""
+}
+
+// cmp compares the log lines using == or by checking each field individually if the ignorer is
+// non-nil.
+func (l *Logger) cmp(hyp, exp string, expLvl level.Level, expMap logmap.MapSlice) bool {
+	if l.ignorer == nil {
+		return hyp == exp
+	}
+
+	var hypMap logmap.MapSlice
+
+	err := hypMap.UnmarshalJSON([]byte(hyp[6:])) // Skip the log level.
+	if err != nil {
+		panic(err)
+	}
+
+	// If there aren't the same number of fields, there's no point in calling the ignorer.
+	if len(hypMap) != len(expMap) {
+		return false
+	}
+
+	// If they're not the same log level, there's no point in calling the ignorer.
+	if !strings.HasPrefix(hyp, expLvl.String()) {
+		return false
+	}
+
+	keysToIgnore := l.ignorer(hypMap.ToStringMap())
+
+	for i := range hypMap {
+		if hypMap[i].Key != expMap[i].Key {
+			return false
+		}
+
+		if sliceContains(keysToIgnore, hypMap[i].Key) {
+			// We're not going to compare the values.
+			continue
+		}
+
+		// Values in hypMap were unmarshaled from JSON, so they're strings. This is not necessarily
+		// the case with values in expMap, so we need to convert them to strings.
+		if hypMap[i].Value != logmap.StringFromValue(expMap[i].Value) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func sliceContains(slice []string, item string) bool {
+	for i := range slice {
+		if slice[i] == item {
+			return true
+		}
+	}
+
+	return false
+}
+
+// replaceNbsp replaces the non-breaking space character (unicode character 0xA0) with a regular
+// space (unicode character 0x20) in certain places where cmp.Diff seems to randomly place them.
+func replaceNbsp(s string) string {
+	// We also need to catch NBSPs at the beginning of the first line.
+	if len(s) >= 4 && s[:4] == "\u00a0\u00a0" {
+		// NBSP is two chars long.
+		s = "  " + s[4:]
+	}
+
+	return nbspReplacer.Replace(s)
+}
+
+var nbspReplacer = strings.NewReplacer(
+	"\n\u00a0\u00a0", "\n  ", // cases like "  string("
+	"\n-\u00a0", "\n- ", // cases like "- <value>"
+	"\n+\u00a0", "\n+ ", // cases like "+ <value>"
+)
+
+// Done signals to the Logger that no more log methods will be called. It checks whether the Logger
+// expected more log messages, and calls runner.Fail if any differences were reported.
+func (l *Logger) Done() {
+	if !l.doFail {
+		return
+	}
+
+	if l.cur < len(l.truth) {
+		// We're missing some log messages that we expected.
+		l.failed = true
+		for ; l.cur < len(l.truth); l.cur++ {
+			l.runner.Log("missing log message (-want +got):\n", replaceNbsp(cmp.Diff(l.truth[l.cur], "")))
+		}
+	}
+
+	if l.failed {
+		if l.actualFile != nil {
+			err := l.actualFile.actuallyWrite()
+			if err != nil {
+				l.error(fmt.Errorf("error writing to actual file: %w", err))
+			}
+		}
+
+		l.runner.Fail()
+	}
+
+	if l.actualFile != nil {
+		err := l.actualFile.Close()
+		if err != nil {
+			l.error(err)
+		}
+	}
+}

--- a/pkg/testinglog/logger_test.go
+++ b/pkg/testinglog/logger_test.go
@@ -1,0 +1,771 @@
+/*
+   Copyright (2020) Cobalt Speech and Language Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package testinglog
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cobaltspeech/log/pkg/level"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// writeTemporaryFile is used by some of the examples to provide a short way to create a file
+// containing a specific string and later delete it. The returned function need only be called if
+// err == nil.
+func writeTemporaryFile(data string) (filename string, remove func(), err error) {
+	var f *os.File
+
+	f, err = ioutil.TempFile("", "")
+	if err != nil {
+		return "", func() {}, err
+	}
+
+	_, err = f.WriteString(data)
+	if err != nil {
+		return "", func() {}, err
+	}
+
+	filename = f.Name()
+	remove = func() {
+		e := os.Remove(filename)
+		if e != nil {
+			fmt.Println(e)
+		}
+	}
+
+	err = f.Close()
+
+	if err != nil {
+		remove()
+	}
+
+	return filename, remove, err
+}
+
+func ExampleWithTruthFile() {
+	// Write an example file.
+	hypFile, remove, err := writeTemporaryFile(strings.Join([]string{
+		`error {"msg":"There was a problem.","data":"3.14"}`,
+		`debug {"msg":"Here's the number of calls.","numCalls":"17"}`,
+	}, "\n"))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	defer remove()
+
+	runner := fakeRunner{}
+
+	logger, err := NewLogger(&runner, WithTruthFile(hypFile))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	logger.Error("msg", "There was a problem.", "data", 3.14)
+	logger.Debug("msg", "Here's some pertinent information.", "numCalls", 17) // doesn't match hyp
+	logger.Trace("msg", "This trace message shouldn't be here.")
+
+	logger.Done()
+
+	fmt.Print(runner.b.String())
+	fmt.Println(runner.failed)
+	// Output:
+	// error {"msg":"There was a problem.","data":"3.14"}
+	// debug {"msg":"Here's some pertinent information.","numCalls":"17"}
+	// unexpected log message (-want +got):
+	//   string(
+	// - 	`debug {"msg":"Here's the number of calls.","numCalls":"17"}`,
+	// + 	`debug {"msg":"Here's some pertinent information.","numCalls":"17"}`,
+	//   )
+	// trace {"msg":"This trace message shouldn't be here."}
+	// unexpected log message (-want +got):
+	//   string(
+	// - 	"",
+	// + 	`trace {"msg":"This trace message shouldn't be here."}`,
+	//   )
+	// true
+}
+
+func ExampleWithActualOutputFile() {
+	hypFile, remove, err := writeTemporaryFile(strings.Join([]string{
+		`error {"msg":"There was a problem.","data":"3.14"}`,
+		`debug {"msg":"Here's the number of calls.","numCalls":"18"}`,
+	}, "\n"))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	defer remove()
+
+	// Get a file we can use for the actual log output.
+	var actualFile string
+	actualFile, remove, err = writeTemporaryFile("")
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	defer remove()
+
+	runner := fakeRunner{}
+
+	logger, err := NewLogger(&runner, WithTruthFile(hypFile), WithActualOutputFile(actualFile))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	logger.Error("msg", "There was a problem.", "data", 3.14)
+	logger.Debug("msg", "Here's some pertinent information.", "numCalls", 18) // doesn't match hyp
+	logger.Trace("msg", "This trace message shouldn't be here.")
+
+	logger.Done()
+
+	// Get the actual log output.
+	var actualBytes []byte
+	actualBytes, err = ioutil.ReadFile(actualFile)
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Print(runner.b.String())
+	fmt.Print(string(actualBytes))
+	fmt.Println(runner.failed)
+	// Output:
+	// unexpected log message (-want +got):
+	//   string(
+	// - 	`debug {"msg":"Here's the number of calls.","numCalls":"18"}`,
+	// + 	`debug {"msg":"Here's some pertinent information.","numCalls":"18"}`,
+	//   )
+	// unexpected log message (-want +got):
+	//   string(
+	// - 	"",
+	// + 	`trace {"msg":"This trace message shouldn't be here."}`,
+	//   )
+	// error {"msg":"There was a problem.","data":"3.14"}
+	// debug {"msg":"Here's some pertinent information.","numCalls":"18"}
+	// trace {"msg":"This trace message shouldn't be here."}
+	// true
+}
+
+func ExampleWithoutFailure() {
+	hypFile, remove, err := writeTemporaryFile(strings.Join([]string{
+		`error {"msg":"There was a problem.","data":"3.14"}`,
+		`debug {"msg":"Here's the number of calls.","numCalls":"19"}`,
+	}, "\n"))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	defer remove()
+
+	runner := fakeRunner{}
+
+	logger, err := NewLogger(&runner, WithTruthFile(hypFile), WithoutFailure())
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	logger.Error("msg", "There was a problem.", "data", 3.14)
+
+	// This log message doesn't match, but we still want the test to pass.
+	logger.Debug("msg", "Here's some pertinent information.", "numCalls", 19)
+
+	logger.Done()
+
+	fmt.Println(runner.failed)
+	// Output:
+	// false
+}
+
+func ExampleWithFieldIgnoreFunc() {
+	hypFile, remove, err := writeTemporaryFile(strings.Join([]string{
+		`trace {"msg":"An ID was generated.","id":"brh634381n1ts5ibr1eg"}`,
+		`debug {"msg":"This ID is deterministic.","id":"42"}`,
+	}, "\n"))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	defer remove()
+
+	runner := fakeRunner{}
+
+	ignorer := func(fields map[string]string) []string {
+		msg, ok := fields["msg"]
+
+		// Ignore only the "id" field in the non-deterministic ID log line.
+		if ok && msg == "An ID was generated." {
+			return []string{"id"}
+		}
+
+		return nil
+	}
+
+	logger, err := NewLogger(&runner, WithTruthFile(hypFile), WithFieldIgnoreFunc(ignorer))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// This is not deterministic.
+	id := strconv.Itoa(rand.Intn(10000000))
+
+	logger.Trace("msg", "An ID was generated.", "id", id)
+	logger.Debug("msg", "This ID is deterministic.", "id", 12) // doesn't match hyp
+
+	logger.Done()
+
+	fmt.Print(strings.Replace(runner.b.String(), id, "<id removed>", 1))
+	// Output:
+	// trace {"msg":"An ID was generated.","id":"<id removed>"}
+	// debug {"msg":"This ID is deterministic.","id":"12"}
+	// unexpected log message (-want +got):
+	//   string(
+	// - 	`debug {"msg":"This ID is deterministic.","id":"42"}`,
+	// + 	`debug {"msg":"This ID is deterministic.","id":"12"}`,
+	//   )
+}
+
+type testingLogMsg struct {
+	lvl     level.Level
+	keyvals []interface{}
+}
+
+func TestWithTruthFile(t *testing.T) { // nolint: funlen // Tests are just long.
+	tests := map[string]struct {
+		// in is the set of log messages that will actually be given to the Logger.
+		in []testingLogMsg
+
+		// expect is the name of a file in "testdata" containing the log messages that the Logger
+		// should expect.
+		expect string
+
+		// hyp is the complete string that we should expect to be written to the test runner given
+		// `expect` and `in`.
+		hyp string
+
+		// expectFail is whether to expect the Logger to call runner.Fail.
+		expectFail bool
+	}{
+		"empty": {
+			expect:     "empty.log",
+			expectFail: false,
+		},
+		"correct": {
+			in: []testingLogMsg{
+				{level.Trace, []interface{}{"msg", "This is just a trace.", "data", 3.14}},
+				{level.Debug, []interface{}{"msg", "This is a debug msg.", "data", []byte{0, 1, 2, 3}}},
+				{level.Info, []interface{}{"msg", "This msg might be useful.", "data", 12}},
+				{level.Error, []interface{}{"msg", "There's a problem.", "data"}}, // missing value
+			},
+			expect: "correct.log",
+			hyp: strings.Join([]string{
+				`trace {"msg":"This is just a trace.","data":"3.14"}`,
+				`debug {"msg":"This is a debug msg.","data":"[0 1 2 3]"}`,
+				`info  {"msg":"This msg might be useful.","data":"12"}`,
+				`error {"msg":"There's a problem.","data":"missing"}`,
+			}, "\n"),
+			expectFail: false,
+		},
+		"bad_order": {
+			in: []testingLogMsg{
+				{level.Trace, []interface{}{"msg", "This is just a trace.", "data", 3.14}},
+				{level.Info, []interface{}{"msg", "This msg might be useful.", "data", 12}},
+				{level.Debug, []interface{}{"msg", "This is a debug msg.", "data", []byte{0, 1, 2, 3}}},
+			},
+			expect: "bad_order.log",
+			hyp: strings.Join([]string{
+				`trace {"msg":"This is just a trace.","data":"3.14"}`,
+				`info  {"msg":"This msg might be useful.","data":"12"}`,
+				"unexpected log message (-want +got):",
+				"  string(",
+				"- 	`" + `debug {"msg":"This is a debug msg.","data":"[0 1 2 3]"}` + "`,",
+				"+ 	`" + `info  {"msg":"This msg might be useful.","data":"12"}` + "`,",
+				"  )",
+				`debug {"msg":"This is a debug msg.","data":"[0 1 2 3]"}`,
+				"unexpected log message (-want +got):",
+				"  string(",
+				"- 	`" + `info  {"msg":"This msg might be useful.","data":"12"}` + "`,",
+				"+ 	`" + `debug {"msg":"This is a debug msg.","data":"[0 1 2 3]"}` + "`,",
+				"  )",
+			}, "\n"),
+			expectFail: true,
+		},
+		"missing_message": {
+			expect: "missing_message.log",
+			hyp: strings.Join([]string{
+				"missing log message (-want +got):",
+				"  string(",
+				"- 	`" + `trace {"msg":"This message should be here."}` + "`,",
+				`+ 	"",`,
+				"  )",
+			}, "\n"),
+			expectFail: true,
+		},
+		"extra_message": {
+			in: []testingLogMsg{
+				{level.Trace, []interface{}{"msg", "This message should not be here."}},
+			},
+			expect: "empty.log",
+			hyp: strings.Join([]string{
+				`trace {"msg":"This message should not be here."}`,
+				"unexpected log message (-want +got):",
+				"  string(",
+				`- 	"",`,
+				"+ 	`" + `trace {"msg":"This message should not be here."}` + "`,",
+				"  )",
+			}, "\n"),
+			expectFail: true,
+		},
+		"exotic_types": {
+			in: []testingLogMsg{
+				{level.Debug, []interface{}{"msg", "Some data.", "data", struct{}{}}},
+			},
+			expect: "empty.log",
+			hyp: strings.Join([]string{
+				`debug {"msg":"Some data.","data":"{}"}`,
+				"unexpected log message (-want +got):",
+				"  string(",
+				`- 	"",`,
+				"+ 	`" + `debug {"msg":"Some data.","data":"{}"}` + "`,",
+				"  )",
+			}, "\n"),
+			expectFail: true,
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			runner := fakeRunner{}
+			logger, err := NewLogger(&runner, WithTruthFile(filepath.Join("testdata", tc.expect)))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			writeLogMsgs(logger, tc.in)
+
+			// The logger shouldn't call Fail until Done is called.
+			if runner.failed {
+				t.Errorf("logger called Fail before Done was called")
+			}
+
+			logger.Done()
+
+			runner.compareOutput(t, tc.hyp, tc.expectFail)
+		})
+	}
+}
+
+func writeLogMsgs(logger *Logger, msgs []testingLogMsg) {
+	for _, msg := range msgs {
+		switch msg.lvl {
+		case level.Error:
+			logger.Error(msg.keyvals...)
+		case level.Info:
+			logger.Info(msg.keyvals...)
+		case level.Debug:
+			logger.Debug(msg.keyvals...)
+		case level.Trace:
+			logger.Trace(msg.keyvals...)
+		default:
+			panic(fmt.Sprintf("test log message had unexpected level: %v", msg.lvl))
+		}
+	}
+}
+
+func (r *fakeRunner) compareOutput(t *testing.T, hyp string, expectFail bool) {
+	exp := r.b.String()
+	expLines := strings.Split(exp, "\n")
+	hypLines := strings.Split(hyp, "\n")
+
+	for len(expLines) < len(hypLines) {
+		expLines = append(expLines, "")
+	}
+
+	for len(hypLines) < len(expLines) {
+		hypLines = append(hypLines, "")
+	}
+
+	for i, hypLine := range hypLines {
+		diff := cmp.Diff(hypLine, expLines[i])
+		if diff != "" {
+			t.Errorf("runner log mismatch on line %d (-want +got):\n%s", i+1, diff)
+		}
+	}
+
+	if t.Failed() {
+		t.Log(exp)
+	}
+
+	diff := cmp.Diff(expectFail, r.failed)
+	if diff != "" {
+		t.Errorf("failure mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestWithTruthFile_panic(t *testing.T) {
+	defer func() {
+		r := recover()
+
+		diff := cmp.Diff("multiple truth sources provided", r)
+		if diff != "" {
+			t.Errorf("panic value different than expected:\n%s", diff)
+		}
+	}()
+
+	_, _ = NewLogger(
+		nil,
+		WithTruthFile(filepath.Join("testdata", "empty.log")),
+		WithTruthFile(filepath.Join("testdata", "correct.log")),
+	)
+}
+
+const nilStr = "<nil>"
+
+func TestWithTruthFile_error(t *testing.T) {
+	hyp := "open testdata/nonexistent.log: no such file or directory"
+	_, exp := NewLogger(nil, WithTruthFile(filepath.Join("testdata", "nonexistent.log")))
+
+	expStr := nilStr
+	if exp != nil {
+		expStr = exp.Error()
+	}
+
+	diff := cmp.Diff(hyp, expStr)
+	if diff != "" {
+		t.Errorf("err differed from expected (-want, +got):\n%s", diff)
+	}
+}
+
+func TestWithActualOutputFile_noTruth(t *testing.T) {
+	// Get a file we can use for the actual log output.
+	actualFile, remove, err := writeTemporaryFile("")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer remove()
+
+	runner := fakeRunner{}
+
+	logger, err := NewLogger(&runner, WithActualOutputFile(actualFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logger.Error("msg", "This is an error we expect to see!")
+	logger.Trace("msg", "This is a trace message.")
+	logger.Done()
+
+	// We don't expect anything to have happened to the test runner.
+	runnerExpect := ""
+	expectFail := false
+	runner.compareOutput(t, runnerExpect, expectFail)
+
+	// Check the file and make sure it's what we expect.
+	hyp := strings.Join([]string{
+		`error {"msg":"This is an error we expect to see!"}`,
+		`trace {"msg":"This is a trace message."}`,
+		``, // We expect a final newline.
+	}, "\n")
+
+	b, err := ioutil.ReadFile(actualFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	diff := cmp.Diff(hyp, string(b))
+	if diff != "" {
+		t.Errorf("unexpected output to actual file (-want, +got):\n%s", diff)
+	}
+}
+
+func TestWithActualOutputFile_withTruthMatch(t *testing.T) {
+	// Make up a filename for the actual output. Since the logs will match, we should expect this
+	// file not to be created.
+	actualFile := filepath.Join("testdata", "this_should_never_exist.log.generated")
+
+	runner := fakeRunner{}
+
+	logger, err := NewLogger(&runner,
+		WithActualOutputFile(actualFile),
+		WithTruthFile(filepath.Join("testdata", "missing_message.log")),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Send the right log message.
+	logger.Trace("msg", "This message should be here.")
+	logger.Done()
+
+	// The runner should have been told nothing.
+	runnerExpect := ""
+	expectFail := false
+	runner.compareOutput(t, runnerExpect, expectFail)
+
+	// The actual output file shouldn't have been created.
+	if _, err := os.Stat(actualFile); err == nil {
+		t.Error("actual file was created but should not have been")
+	}
+}
+
+func TestWithActualOutputFile_withTruthNoMatch(t *testing.T) {
+	// Get a file we can use for the actual log output.
+	actualFile, remove, err := writeTemporaryFile("")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer remove()
+
+	runner := fakeRunner{}
+
+	logger, err := NewLogger(&runner,
+		WithActualOutputFile(actualFile),
+		WithTruthFile(filepath.Join("testdata", "missing_message.log")),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Send no log messages.
+	logger.Done()
+
+	// The runner should have been told about the missing message.
+	runnerExpect := strings.Join([]string{
+		"missing log message (-want +got):",
+		"  string(",
+		"- 	`" + `trace {"msg":"This message should be here."}` + "`,",
+		`+ 	"",`,
+		"  )",
+	}, "\n")
+	expectFail := true
+	runner.compareOutput(t, runnerExpect, expectFail)
+
+	// The actual output should be nothing.
+	b, err := ioutil.ReadFile(actualFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	diff := cmp.Diff("", string(b))
+	if diff != "" {
+		t.Errorf("unexpected output to actual file (-want, +got):\n%s", diff)
+	}
+}
+
+func TestWithActualOutputFile_error(t *testing.T) {
+	// Get a directory we can use as the path for writing the actual file, so it errors.
+	actualFile, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		e := os.RemoveAll(actualFile)
+		if e != nil {
+			t.Fatal(e)
+		}
+	}()
+
+	runner := fakeRunner{}
+
+	_, err = NewLogger(&runner, WithActualOutputFile(actualFile))
+
+	errStr := nilStr
+	if err != nil {
+		errStr = err.Error()
+	}
+
+	hypErr := fmt.Sprintf("open %s: is a directory", actualFile)
+
+	diff := cmp.Diff(hypErr, errStr)
+	if diff != "" {
+		t.Errorf("unexpected error (-want +got):\n%s", diff)
+	}
+}
+
+func TestWithActualOutputFile_errorOnDoneWithTruth(t *testing.T) {
+	// Get a directory we can use as the path for writing the actual file, so it errors.
+	actualFile, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		e := os.RemoveAll(actualFile)
+		if e != nil {
+			t.Fatal(e)
+		}
+	}()
+
+	runner := fakeRunner{}
+
+	logger, err := NewLogger(&runner,
+		WithActualOutputFile(actualFile),
+		WithTruthFile(filepath.Join("testdata", "two.log")),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Forget to send the last log, but do send the first one so we have to write the actual.
+	logger.Info("msg", "This msg might be useful.", "data", 12)
+	logger.Done()
+
+	// We should have received logging errors from the call to Done.
+	runnerExpect := strings.Join([]string{
+		"missing log message (-want +got):",
+		"  string(",
+		"- 	`" + `trace {"msg":"This message should be here."}` + "`,",
+		`+ 	"",`,
+		"  )",
+		fmt.Sprintf(
+			`error {"msg":"logging failure","error":"error writing to actual file: open %s: is a directory"}`+"\n",
+			actualFile,
+		),
+	}, "\n")
+	expectFail := true
+	runner.compareOutput(t, runnerExpect, expectFail)
+}
+
+func TestWithFieldIgnorer(t *testing.T) { // nolint: funlen // Tests are just long.
+	dataIgnorer := func(fields map[string]string) []string {
+		msg, ok := fields["msg"]
+
+		if ok && msg == "This message should be here." {
+			return []string{"data"}
+		}
+
+		return nil
+	}
+
+	tests := map[string]struct {
+		ignorer    FieldIgnoreFunc
+		in         []testingLogMsg
+		expect     string
+		hyp        string
+		expectFail bool
+	}{
+		"extra_key_not_ok": {
+			ignorer: dataIgnorer,
+			in: []testingLogMsg{
+				{level.Info, []interface{}{"msg", "This msg might be useful.", "data", "13"}}, // wrong value
+				{level.Trace, []interface{}{"msg", "This message should be here.", "data"}},   // extra key
+			},
+			expect: "two.log",
+			hyp: strings.Join([]string{
+				`info  {"msg":"This msg might be useful.","data":"13"}`,
+				"unexpected log message (-want +got):",
+				"  string(",
+				"- 	`" + `info  {"msg":"This msg might be useful.","data":"12"}` + "`,",
+				"+ 	`" + `info  {"msg":"This msg might be useful.","data":"13"}` + "`,",
+				"  )",
+				`trace {"msg":"This message should be here.","data":"missing"}`,
+				"unexpected log message (-want +got):",
+				"  string(",
+				"- 	`" + `trace {"msg":"This message should be here."}` + "`,",
+				"+ 	`" + `trace {"msg":"This message should be here.","data":"missing"}` + "`,",
+				"  )",
+			}, "\n"),
+			expectFail: true,
+		},
+		"wrong_keys": {
+			ignorer: dataIgnorer,
+			in: []testingLogMsg{
+				{level.Info, []interface{}{"message", "This msg might be useful.", "data", "12"}}, // wrong key
+				{level.Trace, []interface{}{"msg", "This message should be here."}},
+			},
+			expect: "two.log",
+			hyp: strings.Join([]string{
+				`info  {"message":"This msg might be useful.","data":"12"}`,
+				"unexpected log message (-want +got):",
+				"  string(",
+				"- 	`" + `info  {"msg":"This msg might be useful.","data":"12"}` + "`,",
+				"+ 	`" + `info  {"message":"This msg might be useful.","data":"12"}` + "`,",
+				"  )",
+				`trace {"msg":"This message should be here."}`,
+			}, "\n"),
+			expectFail: true,
+		},
+		"wrong_level": {
+			ignorer: dataIgnorer,
+			in: []testingLogMsg{
+				{level.Error, []interface{}{"msg", "This msg might be useful.", "data", "12"}}, // wrong level
+				{level.Trace, []interface{}{"msg", "This message should be here."}},
+			},
+			expect: "two.log",
+			hyp: strings.Join([]string{
+				`error {"msg":"This msg might be useful.","data":"12"}`,
+				"unexpected log message (-want +got):",
+				"  string(",
+				"- 	`" + `info  {"msg":"This msg might be useful.","data":"12"}` + "`,",
+				"+ 	`" + `error {"msg":"This msg might be useful.","data":"12"}` + "`,",
+				"  )",
+				`trace {"msg":"This message should be here."}`,
+			}, "\n"),
+			expectFail: true,
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := fakeRunner{}
+			logger, err := NewLogger(
+				&runner,
+				WithTruthFile(filepath.Join("testdata", tc.expect)),
+				WithFieldIgnoreFunc(tc.ignorer),
+			)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			writeLogMsgs(logger, tc.in)
+			logger.Done()
+
+			runner.compareOutput(t, tc.hyp, tc.expectFail)
+		})
+	}
+}

--- a/pkg/testinglog/loggerexample_test.go
+++ b/pkg/testinglog/loggerexample_test.go
@@ -1,0 +1,51 @@
+/*
+   Copyright (2020) Cobalt Speech and Language Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package testinglog
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// fakeRunner implements TestRunner, for testing the Logger.
+type fakeRunner struct {
+	b      bytes.Buffer
+	failed bool
+}
+
+func (r *fakeRunner) Fail() {
+	r.failed = true
+}
+
+func (r *fakeRunner) Log(args ...interface{}) {
+	fmt.Fprint(&r.b, args...)
+}
+
+func ExampleLogger() {
+	runner := &fakeRunner{}
+	logger, _ := NewLogger(runner)
+
+	logger.Error("msg", "There was a problem.", "data", 3.14)
+	logger.Debug("msg", "Here's some pertinent information.", "numCalls", 17)
+
+	logger.Done()
+
+	fmt.Println(runner.b.String())
+	// Output:
+	// error {"msg":"There was a problem.","data":"3.14"}
+	// debug {"msg":"Here's some pertinent information.","numCalls":"17"}
+}

--- a/pkg/testinglog/testdata/bad_order.log
+++ b/pkg/testinglog/testdata/bad_order.log
@@ -1,0 +1,3 @@
+trace {"msg":"This is just a trace.","data":"3.14"}
+debug {"msg":"This is a debug msg.","data":"[0 1 2 3]"}
+info  {"msg":"This msg might be useful.","data":"12"}

--- a/pkg/testinglog/testdata/correct.log
+++ b/pkg/testinglog/testdata/correct.log
@@ -1,0 +1,4 @@
+trace {"msg":"This is just a trace.","data":"3.14"}
+debug {"msg":"This is a debug msg.","data":"[0 1 2 3]"}
+info  {"msg":"This msg might be useful.","data":"12"}
+error {"msg":"There's a problem.","data":"missing"}

--- a/pkg/testinglog/testdata/missing_message.log
+++ b/pkg/testinglog/testdata/missing_message.log
@@ -1,0 +1,1 @@
+trace {"msg":"This message should be here."}

--- a/pkg/testinglog/testdata/two.log
+++ b/pkg/testinglog/testdata/two.log
@@ -1,0 +1,2 @@
+info  {"msg":"This msg might be useful.","data":"12"}
+trace {"msg":"This message should be here."}


### PR DESCRIPTION
I had my own ideas about how a test logger should be implemented, so I want to see what you think.

I had a hard time deciding whether we're testing the output of a `LeveledLogger` or *strictly* testing the `Logger` interface. In this implementation, I strictly test the `Logger` interface. This means that I use `cmp.Diff` to compare the objects passed to the logging methods *exactly* as they come, i.e. order matters and string representations don't matter.

We might need to add options to the `cmd.Diff` call to support things like floats.