### PR TITLE
feat: preserve order of keys in leveled logger

### DIFF
--- a/contextual_test.go
+++ b/contextual_test.go
@@ -54,29 +54,30 @@ func TestContextLogger(t *testing.T) {
 	l5 := With(l2)
 	writelogs(l5, "With(key1,empty)")
 
-	want := `
-trace {"label":"default logger","msg":"trace_message"}
-debug {"label":"default logger","msg":"debug_message"}
-info  {"label":"default logger","msg":"info_message"}
-error {"label":"default logger","msg":"error_message"}
-trace {"key1":"value1","label":"With(key1)","msg":"trace_message"}
-debug {"key1":"value1","label":"With(key1)","msg":"debug_message"}
-info  {"key1":"value1","label":"With(key1)","msg":"info_message"}
-error {"key1":"value1","label":"With(key1)","msg":"error_message"}
-trace {"key2":"value2","label":"With(key2)","msg":"trace_message"}
-debug {"key2":"value2","label":"With(key2)","msg":"debug_message"}
-info  {"key2":"value2","label":"With(key2)","msg":"info_message"}
-error {"key2":"value2","label":"With(key2)","msg":"error_message"}
-trace {"key1":"value1","key3":"value3","label":"With(key1,key3)","msg":"trace_message"}
-debug {"key1":"value1","key3":"value3","label":"With(key1,key3)","msg":"debug_message"}
-info  {"key1":"value1","key3":"value3","label":"With(key1,key3)","msg":"info_message"}
-error {"key1":"value1","key3":"value3","label":"With(key1,key3)","msg":"error_message"}
-trace {"key1":"value1","label":"With(key1,empty)","msg":"trace_message"}
-debug {"key1":"value1","label":"With(key1,empty)","msg":"debug_message"}
-info  {"key1":"value1","label":"With(key1,empty)","msg":"info_message"}
-error {"key1":"value1","label":"With(key1,empty)","msg":"error_message"}
+	want := `trace {"msg":"trace_message","label":"default logger"}
+debug {"msg":"debug_message","label":"default logger"}
+info  {"msg":"info_message","label":"default logger"}
+error {"msg":"error_message","label":"default logger"}
+trace {"key1":"value1","msg":"trace_message","label":"With(key1)"}
+debug {"key1":"value1","msg":"debug_message","label":"With(key1)"}
+info  {"key1":"value1","msg":"info_message","label":"With(key1)"}
+error {"key1":"value1","msg":"error_message","label":"With(key1)"}
+trace {"key2":"value2","msg":"trace_message","label":"With(key2)"}
+debug {"key2":"value2","msg":"debug_message","label":"With(key2)"}
+info  {"key2":"value2","msg":"info_message","label":"With(key2)"}
+error {"key2":"value2","msg":"error_message","label":"With(key2)"}
+trace {"key1":"value1","key3":"value3","msg":"trace_message","label":"With(key1,key3)"}
+debug {"key1":"value1","key3":"value3","msg":"debug_message","label":"With(key1,key3)"}
+info  {"key1":"value1","key3":"value3","msg":"info_message","label":"With(key1,key3)"}
+error {"key1":"value1","key3":"value3","msg":"error_message","label":"With(key1,key3)"}
+trace {"key1":"value1","msg":"trace_message","label":"With(key1,empty)"}
+debug {"key1":"value1","msg":"debug_message","label":"With(key1,empty)"}
+info  {"key1":"value1","msg":"info_message","label":"With(key1,empty)"}
+error {"key1":"value1","msg":"error_message","label":"With(key1,empty)"}
 `
 	if got := b.String(); strings.TrimSpace(got) != strings.TrimSpace(want) {
+		t.Log(got)
+		t.Log(want)
 		t.Errorf("default filter level: got %q, want %q", got, want)
 	}
 }

--- a/leveled_test.go
+++ b/leveled_test.go
@@ -101,19 +101,20 @@ func TestLeveledLogger_SetFilterLevel(t *testing.T) {
 	l.SetFilterLevel(level.All)
 	writelogs(l, "SetFilterLevel(All)")
 
-	want := `
-info  {"label":"default filter level","msg":"info_message"}
-error {"label":"default filter level","msg":"error_message"}
-debug {"label":"WithFilterLevel(debug)","msg":"debug_message"}
-info  {"label":"SetFilterLevel(Info)","msg":"info_message"}
-debug {"label":"SetFilterLevel(Info|Debug)","msg":"debug_message"}
-info  {"label":"SetFilterLevel(Info|Debug)","msg":"info_message"}
-trace {"label":"SetFilterLevel(All)","msg":"trace_message"}
-debug {"label":"SetFilterLevel(All)","msg":"debug_message"}
-info  {"label":"SetFilterLevel(All)","msg":"info_message"}
-error {"label":"SetFilterLevel(All)","msg":"error_message"}
+	want := `info  {"msg":"info_message","label":"default filter level"}
+error {"msg":"error_message","label":"default filter level"}
+debug {"msg":"debug_message","label":"WithFilterLevel(debug)"}
+info  {"msg":"info_message","label":"SetFilterLevel(Info)"}
+debug {"msg":"debug_message","label":"SetFilterLevel(Info|Debug)"}
+info  {"msg":"info_message","label":"SetFilterLevel(Info|Debug)"}
+trace {"msg":"trace_message","label":"SetFilterLevel(All)"}
+debug {"msg":"debug_message","label":"SetFilterLevel(All)"}
+info  {"msg":"info_message","label":"SetFilterLevel(All)"}
+error {"msg":"error_message","label":"SetFilterLevel(All)"}
 `
 	if got := b.String(); strings.TrimSpace(got) != strings.TrimSpace(want) {
+		t.Log(got)
+		t.Log(want)
 		t.Errorf("default filter level: got %q, want %q", got, want)
 	}
 }
@@ -130,15 +131,17 @@ func TestLeveledLogger_log_jsonErrors(t *testing.T) {
 	l.Error("msg", &failingTextMarshaler{})
 	l.Error("msg", &failingJSONMarshaler{})
 
-	want := `
-error {}
+	//nolint: lll // log truth can't be broken into multiple lines
+	want := `error {}
 error {"msg":"missing"}
 error {"msg":"test this"}
-error {"msg":"logging failure","error":"json: error calling MarshalText for type *log.failingTextMarshaler: invalid value"}
-error {"msg":"logging failure","error":"json: error calling MarshalJSON for type *log.failingJSONMarshaler: invalid value"}
+error {"msg":"logging failure","error":"json: error calling MarshalJSON for type log.mapSlice: json: error calling MarshalText for type *log.failingTextMarshaler: invalid value"}
+error {"msg":"logging failure","error":"json: error calling MarshalJSON for type log.mapSlice: json: error calling MarshalJSON for type *log.failingJSONMarshaler: invalid value"}
 `
 
 	if got := b.String(); strings.TrimSpace(got) != strings.TrimSpace(want) {
+		t.Log(got)
+		t.Log(want)
 		t.Errorf("log_jsonErrors: got %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
The leveled logger was using a map, and the order of entries in the JSON message
was sorted by the key label.  That made the input less human readable.  This
commit fixes that by using a map slice instead of a map.