### PR TITLE
create directory for generated file if needed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/cobaltspeech/log
 
 go 1.14
 
-require github.com/google/go-cmp v0.4.1
+require github.com/google/go-cmp v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
-github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
+github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/logmap/logmap.go
+++ b/internal/logmap/logmap.go
@@ -76,8 +76,6 @@ type MapSlice []MapItem
 
 // UnmarshalJSON adds entries from the JSON object to the MapSlice.
 func (ms *MapSlice) UnmarshalJSON(b []byte) error {
-	indexCounter = 0
-
 	m := map[string]IndexedMapValue{}
 	if err := json.Unmarshal(b, &m); err != nil {
 		return err

--- a/pkg/testinglog/lastminutefilewriter.go
+++ b/pkg/testinglog/lastminutefilewriter.go
@@ -20,11 +20,13 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 )
 
 // lastMinuteFileWriter caches writes until ActuallyWrite is called. It only creates a file at the
-// specified path when it begins to actually write.
+// specified path when it begins to actually write. It also creates the directory containing the
+// specified path at that point.
 type lastMinuteFileWriter struct {
 	path string
 
@@ -58,7 +60,10 @@ func (fw *lastMinuteFileWriter) actuallyWrite() error {
 		return nil
 	}
 
-	var err error
+	err := os.MkdirAll(filepath.Dir(fw.path), os.ModePerm)
+	if err != nil {
+		return err
+	}
 
 	fw.f, err = os.Create(fw.path)
 	if err != nil {


### PR DESCRIPTION
This supports the pattern of generating the truth file by getting the actual log output and renaming it.