### PR TITLE
update linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,8 @@
 linters-settings:
   dupl:
     threshold: 100
+  exhaustive:
+    default-signifies-exhaustive: true
   funlen:
     lines: 100
     statements: 50
@@ -33,6 +35,9 @@ linters-settings:
         checks: argument,case,condition,return
   govet:
     check-shadowing: true
+    enable-all: true
+    disable:
+      - fieldalignment
   lll:
     line-length: 140
   maligned:
@@ -45,49 +50,81 @@ linters:
   # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
   disable-all: true
   enable:
+    - asciicheck
     - bodyclose
     - deadcode
     - depguard
     - dogsled
     - dupl
+    - durationcheck
     - errcheck
+    - exhaustive
+    - exportloopref
     - funlen
+    - gci
     - gochecknoinits
     - goconst
     - gocritic
     - gocyclo
+    - goerr113
     - gofmt
+    - gofumpt
     - goimports
     - golint
     - gomnd
+    - gomoddirectives
     - goprintffuncname
     - gosec
     - gosimple
     - govet
+    - ifshort
     - ineffassign
-    - interfacer
     - lll
+    - makezero
     - misspell
     - nakedret
+    - nestif
+    - nilerr
+    - nlreturn
     - nolintlint
-    - rowserrcheck
-    - scopelint
+    - prealloc
+    - predeclared
+    - revive
     - staticcheck
     - structcheck
     - stylecheck
+    - thelper
+    - tparallel
     - typecheck
     - unconvert
     - unparam
     - unused
     - varcheck
+    - wastedassign
+    - whitespace
     - wsl
 
-  # don't enable:
+  # not enabled:
+  # - cyclop
+  # - exhaustivestruct
+  # - forbidigo
+  # - forcetypeassert
   # - gochecknoglobals
   # - gocognit
+  # - godot
   # - godox
+  # - goheader
+  # - gomodguard
+  # - importas
+  # - interfacer
   # - maligned
-  # - prealloc
+  # - noctx
+  # - paralleltest
+  # - rowserrcheck
+  # - scopelint
+  # - sqlclosecheck
+  # - testpackage
+  # - wrapcheck
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-// Copyright (2020) Cobalt Speech and Language Inc.
+// Copyright (2021) Cobalt Speech and Language Inc.
 
 // Keep only 10 builds on Jenkins
 properties([

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,17 @@
 # Needed tools are installed to BINDIR.
 BINDIR := ./tmp/bin
 
-LINTER := $(BINDIR)/golangci-lint
-LINTER_VERSION := 1.30.0
+LINTER_VERSION := 1.39.0
+LINTER := $(BINDIR)/golangci-lint_$(LINTER_VERSION)
 
 # Linux vs Darwin detection for the machine on which the build is taking place (not to be used for the build target)
 DEV_OS := $(shell uname -s | tr A-Z a-z)
 
 $(LINTER):
 	mkdir -p $(BINDIR)
-	wget "https://github.com/golangci/golangci-lint/releases/download/v$(LINTER_VERSION)/golangci-lint-$(LINTER_VERSION)-$(DEV_OS)-amd64.tar.gz" -O - | tar -xz -C $(BINDIR) --strip-components=1 --exclude=README.md --exclude=LICENSE
+	wget "https://github.com/golangci/golangci-lint/releases/download/v$(LINTER_VERSION)/golangci-lint-$(LINTER_VERSION)-$(DEV_OS)-amd64.tar.gz" -O - \
+		| tar -xz -C $(BINDIR) --strip-components=1 --exclude=README.md --exclude=LICENSE
+	mv $(BINDIR)/golangci-lint $(LINTER)
 
 # Run go-fmt on all go files.  We list all go files in the repository, run
 # gofmt.  gofmt produces output with a list of files that have fmt errors.  If

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (2020) Cobalt Speech and Language Inc.
+# Copyright (2021) Cobalt Speech and Language Inc.
 
 # Needed tools are installed to BINDIR.
 BINDIR := ./tmp/bin

--- a/contextual.go
+++ b/contextual.go
@@ -1,5 +1,5 @@
 /*
-   Copyright (2020) Cobalt Speech and Language Inc.
+   Copyright (2021) Cobalt Speech and Language Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/contextual_test.go
+++ b/contextual_test.go
@@ -1,5 +1,5 @@
 /*
-   Copyright (2020) Cobalt Speech and Language Inc.
+   Copyright (2021) Cobalt Speech and Language Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/discard.go
+++ b/discard.go
@@ -1,5 +1,5 @@
 /*
-   Copyright (2020) Cobalt Speech and Language Inc.
+   Copyright (2021) Cobalt Speech and Language Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/discard_test.go
+++ b/discard_test.go
@@ -1,5 +1,5 @@
 /*
-   Copyright (2020) Cobalt Speech and Language Inc.
+   Copyright (2021) Cobalt Speech and Language Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/internal/logmap/logmap.go
+++ b/internal/logmap/logmap.go
@@ -87,7 +87,7 @@ func (ms *MapSlice) UnmarshalJSON(b []byte) error {
 		index uint64
 	}
 
-	var sorted []indexedEntry
+	sorted := make([]indexedEntry, 0, len(m))
 	for k, v := range m {
 		sorted = append(sorted, indexedEntry{MapItem{Key: k, Value: v.Value}, v.Index})
 	}

--- a/internal/logmap/logmap.go
+++ b/internal/logmap/logmap.go
@@ -1,5 +1,5 @@
 /*
-   Copyright (2020) Cobalt Speech and Language Inc.
+   Copyright (2021) Cobalt Speech and Language Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/internal/logmap/logmap_test.go
+++ b/internal/logmap/logmap_test.go
@@ -17,6 +17,7 @@
 package logmap
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -25,6 +26,8 @@ import (
 )
 
 func TestFromKeyvals(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		in  []interface{}
 		out MapSlice
@@ -71,6 +74,8 @@ func TestFromKeyvals(t *testing.T) {
 const nilStr = "<nil>"
 
 func TestMapSlice_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		starting MapSlice
 		in       string
@@ -141,6 +146,8 @@ func TestMapSlice_UnmarshalJSON(t *testing.T) {
 }
 
 func TestMapSlice_String(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		starting MapSlice
 		out      string
@@ -199,6 +206,8 @@ func TestMapSlice_String(t *testing.T) {
 }
 
 func TestMapSlice_ToStringMap(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		in  MapSlice
 		out map[string]string
@@ -237,6 +246,8 @@ func TestMapSlice_ToStringMap(t *testing.T) {
 }
 
 func TestMapSlice_StringFromValue_panic(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		in    interface{}
 		panic interface{}
@@ -306,7 +317,7 @@ func newFailingTextMarshaler() *failingTextMarshaler {
 }
 
 func (f *failingTextMarshaler) MarshalText() ([]byte, error) {
-	return nil, fmt.Errorf("this error is on purpose")
+	return nil, errOnPurpose
 }
 
 type failingJSONMarshaler testJSONMarshaler
@@ -316,5 +327,7 @@ func newFailingJSONMarshaler() *failingJSONMarshaler {
 }
 
 func (f *failingJSONMarshaler) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("this error is on purpose")
+	return nil, errOnPurpose
 }
+
+var errOnPurpose = errors.New("this error is on purpose")

--- a/internal/logmap/logmap_test.go
+++ b/internal/logmap/logmap_test.go
@@ -1,5 +1,5 @@
 /*
-   Copyright (2020) Cobalt Speech and Language Inc.
+   Copyright (2021) Cobalt Speech and Language Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/leveled.go
+++ b/leveled.go
@@ -126,6 +126,7 @@ func (l *LeveledLogger) log(lvl level.Level, keyvals ...interface{}) {
 	line, err := ms.JSONString()
 	if err != nil {
 		l.logger.Printf(`%-5s {"msg":"logging failure","error":%q}`, level.Error, err)
+
 		return
 	}
 

--- a/leveled.go
+++ b/leveled.go
@@ -1,5 +1,5 @@
 /*
-   Copyright (2020) Cobalt Speech and Language Inc.
+   Copyright (2021) Cobalt Speech and Language Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/leveled_test.go
+++ b/leveled_test.go
@@ -19,7 +19,7 @@ package log
 import (
 	"bufio"
 	"bytes"
-	"fmt"
+	"errors"
 	"log"
 	"os"
 	"regexp"
@@ -52,6 +52,8 @@ func TestLeveledLogger_WithOutput(t *testing.T) {
 }
 
 func logAndTest(t *testing.T, l Logger, b *bytes.Buffer) {
+	t.Helper()
+
 	l.Error("msg", "test_message")
 
 	wantJSON := `{"msg":"test_message"}`
@@ -60,7 +62,6 @@ func logAndTest(t *testing.T, l Logger, b *bytes.Buffer) {
 	pattern := "^" + rDate + " " + rTime + " error " + wantJSON + "\n"
 
 	matched, err := regexp.Match(pattern, b.Bytes())
-
 	if err != nil {
 		t.Fatalf("pattern %q did not compile: %s", pattern, err)
 	}
@@ -188,12 +189,14 @@ func TestLeveledLogger_Concurrent(t *testing.T) {
 type failingTextMarshaler struct{}
 
 func (v *failingTextMarshaler) MarshalText() ([]byte, error) {
-	return nil, fmt.Errorf("invalid value")
+	return nil, errInvalidValue
 }
 
 // failingJSONMarshaler implements json.Marshaler that fails
 type failingJSONMarshaler struct{}
 
 func (v *failingJSONMarshaler) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("invalid value")
+	return nil, errInvalidValue
 }
+
+var errInvalidValue = errors.New("invalid value")

--- a/leveled_test.go
+++ b/leveled_test.go
@@ -1,5 +1,5 @@
 /*
-   Copyright (2020) Cobalt Speech and Language Inc.
+   Copyright (2021) Cobalt Speech and Language Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/log.go
+++ b/log.go
@@ -1,5 +1,5 @@
 /*
-   Copyright (2020) Cobalt Speech and Language Inc.
+   Copyright (2021) Cobalt Speech and Language Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pkg/level/level.go
+++ b/pkg/level/level.go
@@ -27,9 +27,11 @@ const (
 	Error
 )
 
-const None Level = 0
-const Default Level = Info | Error
-const All Level = Trace | Debug | Info | Error
+const (
+	None    Level = 0
+	Default Level = Info | Error
+	All     Level = Trace | Debug | Info | Error
+)
 
 // levelCodes provides a string representation of different supported levels.
 var levelCodes = map[Level]string{

--- a/pkg/level/level.go
+++ b/pkg/level/level.go
@@ -1,5 +1,5 @@
 /*
-   Copyright (2020) Cobalt Speech and Language Inc.
+   Copyright (2021) Cobalt Speech and Language Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pkg/level/level_test.go
+++ b/pkg/level/level_test.go
@@ -1,5 +1,5 @@
 /*
-   Copyright (2020) Cobalt Speech and Language Inc.
+   Copyright (2021) Cobalt Speech and Language Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pkg/testinglog/lastminutefilewriter.go
+++ b/pkg/testinglog/lastminutefilewriter.go
@@ -38,7 +38,8 @@ type lastMinuteFileWriter struct {
 }
 
 func newLastMinuteFileWriter(file string) *lastMinuteFileWriter {
-	b := bytes.Buffer{}
+	var b bytes.Buffer
+
 	return &lastMinuteFileWriter{path: file, w: &b, b: &b}
 }
 

--- a/pkg/testinglog/lastminutefilewriter.go
+++ b/pkg/testinglog/lastminutefilewriter.go
@@ -1,5 +1,5 @@
 /*
-   Copyright (2020) Cobalt Speech and Language Inc.
+   Copyright (2021) Cobalt Speech and Language Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pkg/testinglog/lastminutefilewriter_test.go
+++ b/pkg/testinglog/lastminutefilewriter_test.go
@@ -70,6 +70,7 @@ func TestLastMinuteFileWriter_concurrent(t *testing.T) {
 	for _, line := range readLines(t, tempFile) {
 		if !strings.HasPrefix(line, "this is line ") {
 			t.Errorf(`found unexpected line "%s"`, line)
+
 			continue
 		}
 
@@ -78,11 +79,13 @@ func TestLastMinuteFileWriter_concurrent(t *testing.T) {
 		val, err = strconv.Atoi(line[len("this is line "):])
 		if err != nil {
 			t.Errorf(`found unexpected line "%s": %v`, line, err)
+
 			continue
 		}
 
 		if _, ok := found[val]; ok {
 			t.Errorf(`found duplicate line "%s"`, line)
+
 			continue
 		}
 
@@ -97,6 +100,8 @@ func TestLastMinuteFileWriter_concurrent(t *testing.T) {
 }
 
 func makeTempFile(t *testing.T) string {
+	t.Helper()
+
 	f, err := ioutil.TempFile("", "")
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
@@ -113,6 +118,8 @@ func makeTempFile(t *testing.T) string {
 }
 
 func readLines(t *testing.T, file string) []string {
+	t.Helper()
+
 	b, err := ioutil.ReadFile(file)
 	if err != nil {
 		t.Fatalf("error reading file: %v", err)

--- a/pkg/testinglog/lastminutefilewriter_test.go
+++ b/pkg/testinglog/lastminutefilewriter_test.go
@@ -1,5 +1,5 @@
 /*
-   Copyright (2020) Cobalt Speech and Language Inc.
+   Copyright (2021) Cobalt Speech and Language Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pkg/testinglog/logger.go
+++ b/pkg/testinglog/logger.go
@@ -24,10 +24,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/cobaltspeech/log/internal/logmap"
 	"github.com/cobaltspeech/log/pkg/level"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 // Logger logs messages to a test runner, and can optionally report differences between log messages
@@ -94,13 +94,14 @@ func NewLogger(runner TestRunner, opts ...LoggerOption) (*Logger, error) {
 // truth file, and testdata/t.Name()/test.log.generated will contain the actual output when it
 // differs from the truth file.
 func NewConvenientLogger(tb testing.TB, opts ...LoggerOption) *Logger {
+	tb.Helper()
+
 	logFile := filepath.Join("testdata", tb.Name(), "test.log")
 
 	logger, err := NewLogger(tb, append(opts,
 		WithTruthFile(logFile),
 		WithActualOutputFile(logFile+".generated"),
 	)...)
-
 	if err != nil {
 		tb.Fatalf("create testing logger: %v", err)
 	}
@@ -160,6 +161,7 @@ func WithTruthFile(file string) LoggerOption {
 func WithActualOutputFile(file string) LoggerOption {
 	return func(l *Logger) error {
 		l.actualFile = newLastMinuteFileWriter(file)
+
 		return nil
 	}
 }
@@ -169,6 +171,7 @@ func WithActualOutputFile(file string) LoggerOption {
 func WithoutFailure() LoggerOption {
 	return func(l *Logger) error {
 		l.doFail = false
+
 		return nil
 	}
 }
@@ -185,6 +188,7 @@ type FieldIgnoreFunc func(fields map[string]string) []string
 func WithFieldIgnoreFunc(ignorer FieldIgnoreFunc) LoggerOption {
 	return func(l *Logger) error {
 		l.ignorer = ignorer
+
 		return nil
 	}
 }
@@ -240,6 +244,7 @@ func (l *Logger) Trace(keyvals ...interface{}) {
 func (l *Logger) log(args ...interface{}) {
 	if l.actualFile == nil {
 		l.runner.Log(args...)
+
 		return
 	}
 

--- a/pkg/testinglog/logger.go
+++ b/pkg/testinglog/logger.go
@@ -1,5 +1,5 @@
 /*
-   Copyright (2020) Cobalt Speech and Language Inc.
+   Copyright (2021) Cobalt Speech and Language Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pkg/testinglog/logger_test.go
+++ b/pkg/testinglog/logger_test.go
@@ -26,9 +26,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cobaltspeech/log/pkg/level"
-
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/cobaltspeech/log/pkg/level"
 )
 
 // writeTemporaryFile is used by some of the examples to provide a short way to create a file
@@ -72,6 +72,7 @@ func ExampleWithTruthFile() {
 	}, "\n"))
 	if err != nil {
 		fmt.Println(err)
+
 		return
 	}
 
@@ -82,6 +83,7 @@ func ExampleWithTruthFile() {
 	logger, err := NewLogger(&runner, WithTruthFile(hypFile))
 	if err != nil {
 		fmt.Println(err)
+
 		return
 	}
 
@@ -117,6 +119,7 @@ func ExampleWithActualOutputFile() {
 	}, "\n"))
 	if err != nil {
 		fmt.Println(err)
+
 		return
 	}
 
@@ -128,6 +131,7 @@ func ExampleWithActualOutputFile() {
 
 	if err != nil {
 		fmt.Println(err)
+
 		return
 	}
 
@@ -138,6 +142,7 @@ func ExampleWithActualOutputFile() {
 	logger, err := NewLogger(&runner, WithTruthFile(hypFile), WithActualOutputFile(actualFile))
 	if err != nil {
 		fmt.Println(err)
+
 		return
 	}
 
@@ -153,6 +158,7 @@ func ExampleWithActualOutputFile() {
 
 	if err != nil {
 		fmt.Println(err)
+
 		return
 	}
 
@@ -183,6 +189,7 @@ func ExampleWithoutFailure() {
 	}, "\n"))
 	if err != nil {
 		fmt.Println(err)
+
 		return
 	}
 
@@ -193,6 +200,7 @@ func ExampleWithoutFailure() {
 	logger, err := NewLogger(&runner, WithTruthFile(hypFile), WithoutFailure())
 	if err != nil {
 		fmt.Println(err)
+
 		return
 	}
 
@@ -215,6 +223,7 @@ func ExampleWithFieldIgnoreFunc() {
 	}, "\n"))
 	if err != nil {
 		fmt.Println(err)
+
 		return
 	}
 
@@ -236,6 +245,7 @@ func ExampleWithFieldIgnoreFunc() {
 	logger, err := NewLogger(&runner, WithTruthFile(hypFile), WithFieldIgnoreFunc(ignorer))
 	if err != nil {
 		fmt.Println(err)
+
 		return
 	}
 
@@ -415,6 +425,8 @@ func writeLogMsgs(logger *Logger, msgs []testingLogMsg) {
 }
 
 func (r *fakeRunner) compareOutput(t *testing.T, hyp string, expectFail bool) {
+	t.Helper()
+
 	exp := r.b.String()
 	expLines := strings.Split(exp, "\n")
 	hypLines := strings.Split(hyp, "\n")
@@ -498,7 +510,6 @@ func TestWithTruthFile_noexist(t *testing.T) {
 func TestWithActualOutputFile_noTruth(t *testing.T) {
 	// Get a file we can use for the actual log output.
 	actualFile, remove, err := writeTemporaryFile("")
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -572,7 +583,6 @@ func TestWithActualOutputFile_withTruthMatch(t *testing.T) {
 func TestWithActualOutputFile_withTruthNoMatch(t *testing.T) {
 	// Get a file we can use for the actual log output.
 	actualFile, remove, err := writeTemporaryFile("")
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -691,6 +701,8 @@ func TestWithActualOutputFile_errorOnDoneWithTruth(t *testing.T) {
 }
 
 func TestWithFieldIgnorer(t *testing.T) { // nolint: funlen // Tests are just long.
+	t.Parallel()
+
 	dataIgnorer := func(fields map[string]string) []string {
 		msg, ok := fields["msg"]
 
@@ -781,7 +793,6 @@ func TestWithFieldIgnorer(t *testing.T) { // nolint: funlen // Tests are just lo
 				WithTruthFile(filepath.Join("testdata", tc.expect)),
 				WithFieldIgnoreFunc(tc.ignorer),
 			)
-
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/testinglog/logger_test.go
+++ b/pkg/testinglog/logger_test.go
@@ -1,5 +1,5 @@
 /*
-   Copyright (2020) Cobalt Speech and Language Inc.
+   Copyright (2021) Cobalt Speech and Language Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pkg/testinglog/loggerexample_test.go
+++ b/pkg/testinglog/loggerexample_test.go
@@ -1,5 +1,5 @@
 /*
-   Copyright (2020) Cobalt Speech and Language Inc.
+   Copyright (2021) Cobalt Speech and Language Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
I tried to add `goheader` too, but there's a bug that won't allow multi-line headers with indentation (like we have).