### PR TITLE
fix(testinglog): allow concurrent logging

### DIFF
--- a/pkg/testinglog/testdata/concurrent.log
+++ b/pkg/testinglog/testdata/concurrent.log
@@ -1,0 +1,3 @@
+info  {"msg":"This is a concurrent message."}
+info  {"msg":"This is a concurrent message."}
+info  {"msg":"This is a concurrent message."}


### PR DESCRIPTION
The race detector noticed a race that occurred when my test code was doing concurrent logging. The `LeveledLogger` is thread-safe because it wraps `log.Logger` (which does its own locking), but this was not the case with `testinglog.Logger`.