### PR TITLE
CU-1y8hcm4 feat(testinglog): add WithIgnoreOrder option when comparing logs 

### DIFF
--- a/pkg/level/level.go
+++ b/pkg/level/level.go
@@ -17,6 +17,8 @@
 // Package level defines the supported logging levels
 package level
 
+import "strings"
+
 // Level enumerates different logging levels.
 type Level byte
 
@@ -35,10 +37,13 @@ const (
 
 // levelCodes provides a string representation of different supported levels.
 var levelCodes = map[Level]string{
-	Trace: "trace",
-	Debug: "debug",
-	Info:  "info",
-	Error: "error",
+	Trace:   "trace",
+	Debug:   "debug",
+	Info:    "info",
+	Error:   "error",
+	All:     "all",
+	Default: "default",
+	None:    "none",
 }
 
 func (l Level) String() string {
@@ -64,4 +69,18 @@ func Verbosity(v int) Level {
 	}
 
 	return l
+}
+
+// FromString converts the given string label to the appropriate Level. If the
+// string does not map to a valid logging level, `None` is returned.
+func FromString(s string) Level {
+	s = strings.ToLower(strings.TrimSpace(s))
+
+	for level, levelStr := range levelCodes {
+		if levelStr == s {
+			return level
+		}
+	}
+
+	return None
 }

--- a/pkg/level/level_test.go
+++ b/pkg/level/level_test.go
@@ -56,3 +56,29 @@ func TestLevel_Verbosity(t *testing.T) {
 		}
 	}
 }
+
+func TestLevel_FromString(t *testing.T) {
+	tests := []struct {
+		str  string
+		want Level
+	}{
+		{Trace.String(), Trace},
+		{Debug.String(), Debug},
+		{Info.String(), Info},
+		{Error.String(), Error},
+		{Default.String(), Default},
+		{All.String(), All},
+		{None.String(), None},
+		{"unknown ", None},
+		{"info  ", Info},
+		{"  info  ", Info},
+		{"INFO", Info},
+		{"info level", None},
+	}
+
+	for _, tc := range tests {
+		if got := FromString(tc.str); got != tc.want {
+			t.Errorf("incorrect level mapping for string=%q", tc.str)
+		}
+	}
+}

--- a/pkg/testinglog/lastminutefilewriter.go
+++ b/pkg/testinglog/lastminutefilewriter.go
@@ -56,6 +56,11 @@ func (fw *lastMinuteFileWriter) actuallyWrite() error {
 	fw.lock.Lock()
 	defer fw.lock.Unlock()
 
+	if fw.path == "" {
+		// No actual file path was specified.
+		return nil
+	}
+
 	if fw.f != nil {
 		// We already called actuallyWrite.
 		return nil

--- a/pkg/testinglog/logger.go
+++ b/pkg/testinglog/logger.go
@@ -127,16 +127,20 @@ func NewConvenientLogger(tb testing.TB, opts ...LoggerOption) *Logger {
 
 type LoggerOption func(*Logger) error
 
-// WithTruthFile sets the Logger to compare each log message with the log text in the provided file.
-// Each expected log line should be separated from the next by a newline. If there are any
-// differences between expected and received log lines, they are reported to the test runner and the
-// runner's Fail method will be called when Done is called (unless WithoutFailure is used in
+// WithTruthFile sets the Logger to compare each log message with the log text
+// in the provided file. Each expected log line should be separated from the
+// next by a newline. If there are any differences between expected and received
+// log lines, they are reported to the test runner and the runner's Fail method
+// will be called when Done is called (unless WithoutFailure is used in
 // conjunction with this option).
 //
-// This function does not handle cases where the logging output order is non-deterministic (e.g. if
-// the function being tested uses multiple goroutines).
+// If the logging output order is non-deterministic (e.g. if the function being
+// tested uses multiple goroutines), the WithIgnoreOrder() option can be used
+// along with this option to handle such cases.
 //
-// If the provided file does not exist, the Logger will not expect any log lines.
+//
+// If the provided file does not exist, the Logger will not expect any log
+// lines.
 func WithTruthFile(file string) LoggerOption {
 	var lines []string
 


### PR DESCRIPTION
  - Added `WithIgnoreOrder` options that let's users setup a testing logger
    that will ignore the order in which logging messages are received. This
    is useful for concurrent use cases where the order in which logs are
    received may be different but are nonetheless correct.

  - Added unit tests to test the new functionality.

  - Refactored the `lastminutefilewriter` to allow creating a "memory" only
    writer which only writes to the byte buffer.

  - Added a `FromString()` method to convert string labels for logging
    levels into a `Level`. This is useful when parsing log messages and
    wanting to get the exact logging level from the logged string.